### PR TITLE
Use as a microservice

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,7 +1,7 @@
 runtime: python27
 api_version: 1
 threadsafe: true
-# service: ganban
+service: default
 
 libraries:
   - name: webapp2

--- a/app.yaml
+++ b/app.yaml
@@ -1,6 +1,7 @@
 runtime: python27
 api_version: 1
 threadsafe: true
+# service: ganban
 
 libraries:
   - name: webapp2
@@ -21,3 +22,4 @@ handlers:
 
   - url: /.*
     script: ganban.app
+    # login: admin

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -1,0 +1,9 @@
+from google.appengine.api.modules.modules import get_current_module_name
+
+
+# Sets the namespace to service specified in app.yaml
+def namespace_manager_default_namespace_for_request():
+    if get_current_module_name() == "default":
+        return None
+    else:
+        return get_current_module_name()


### PR DESCRIPTION
I work on many AppEngine projects, one interesting way to use Ganban would be to deploy it into your AppEngine environment as a [microservice](https://cloud.google.com/appengine/docs/python/microservices-on-app-engine), alongside the project you're working on

An important things to consider in this case is to make sure you're using [namespaces](https://cloud.google.com/appengine/docs/python/multitenancy/multitenancy). This way you don't have any overlap on the application you're working on when Ganban is running in parallel.

