### PR TITLE
Cleanup javascript to use a Card object.

### DIFF
--- a/ganban.py
+++ b/ganban.py
@@ -21,7 +21,7 @@ if not Board.query(Board.name == 'Done').fetch(1):
 app = webapp2.WSGIApplication([
     webapp2.Route(r'/', handler=web.RootHandler, methods=['GET']),
     webapp2.Route(r'/welcome', handler=web.WelcomeHandler, methods=['GET']),
-    webapp2.Route(r'/api/cards', handler=api.CreateCardHandler, methods=['POST']),
+    webapp2.Route(r'/api/cards', handler=api.CardHandler, methods=['POST', 'GET']),
     webapp2.Route(r'/api/cards/<card_id>', handler=api.GetCardHandler, methods=['GET']),
     webapp2.Route(r'/api/cards/<card_id>', handler=api.UpdateCardHandler, methods=['PUT']),
     webapp2.Route(r'/api/cards/<card_id>', handler=api.DestroyCardHandler, methods=['DELETE']),

--- a/handlers/api.py
+++ b/handlers/api.py
@@ -39,8 +39,14 @@ class UpdateCardHandler(ApiHandler):
         self.response.out.write(json.dumps(card.to_dict()))
 
 
-class CreateCardHandler(ApiHandler):
+class CardHandler(ApiHandler):
+    def get(self):
+        ''' Get all cards '''
+        cards = [card.to_dict() for card in Card.query()]
+        self.response.out.write(json.dumps(cards))
+
     def post(self):
+        ''' Create new card '''
         board = self.get_board(self.request.get('board_id'))
 
         card = Card(board_key=board.key,

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -7,29 +7,6 @@
       </button>
     </div>
     <div id='{{ board.key.id() }}' class="panel-body cards-board">
-      {% for c in board.cards() %}
-        {{ card(c) }}
-      {% endfor %}
-    </div>
-  </div>
-{%- endmacro %}
-
-{% macro card(card) -%}
-  <div class="card panel panel-default" id='{{ card.key.id() }}' data-board-id='{{ card.board_key.id() }}'>
-    <div class="panel-body">
-      <p><strong>#{{ card.key.id() }}</strong></p>
-      <p class='content'>{{ card.content }}</p>
-      <div class='pull-left'>
-        <span class="text-muted">{{ card.author().email }}</span>
-      </div>
-      <div class='pull-right'>
-        <button type="button" class="btn btn-xs btn-default edit-card">
-          <span class='glyphicon glyphicon-pencil' aria-hidden="true"></span>
-        </button>
-        <button type="button" class="btn btn-xs btn-default delete-card">
-          <span class='glyphicon glyphicon-trash' aria-hidden="true"></span>
-        </button>
-      </div>
     </div>
   </div>
 {%- endmacro %}


### PR DESCRIPTION
**The context of this change**: We need to add new properties to cards, how do we reduce code change required?

Remove parameters and opt for passing the object around
Make the html AND form use inputs so we can generate a Card object using Card.getCardFromElement for both types of elements
Remove card macro, and opt use initCards so we’re not duplicating the template

This change should remove more code than add! 